### PR TITLE
update: bugsnag-dsym-upload v2.1.0

### DIFF
--- a/Formula/bugsnag-dsym-upload.rb
+++ b/Formula/bugsnag-dsym-upload.rb
@@ -1,8 +1,8 @@
 class BugsnagDsymUpload < Formula
   desc "Commands for uploading files to Bugsnag via the upload APIs"
   homepage "https://docs.bugsnag.com/api/dsym-upload"
-  url "https://github.com/bugsnag/bugsnag-dsym-upload/archive/v2.0.0.tar.gz"
-  sha256 "182e99f49ae6915c61d09cd705d67d304f6cf9f34fe4abb8c0b9668944899b98"
+  url "https://github.com/bugsnag/bugsnag-dsym-upload/archive/v2.1.0.tar.gz"
+  sha256 "5fd8d640f91c6644ffdc90b7b5cc87070386799e6272d87e41b13f39dda75f68"
   license "MIT"
   head "https://github.com/bugsnag/bugsnag-dsym-upload"
   bottle :unneeded


### PR DESCRIPTION
## Goal

Updating our Homebrew tap to point to the new https://github.com/bugsnag/bugsnag-dsym-upload/releases/tag/v2.1.0 of the `bugsnag-dsym-upload` tool.