### PR TITLE
update formula to point to bugsnag-dsym-upload v2.2.0

### DIFF
--- a/Formula/bugsnag-dsym-upload.rb
+++ b/Formula/bugsnag-dsym-upload.rb
@@ -1,8 +1,8 @@
 class BugsnagDsymUpload < Formula
   desc "Commands for uploading files to Bugsnag via the upload APIs"
   homepage "https://docs.bugsnag.com/api/dsym-upload"
-  url "https://github.com/bugsnag/bugsnag-dsym-upload/archive/v2.1.0.tar.gz"
-  sha256 "5fd8d640f91c6644ffdc90b7b5cc87070386799e6272d87e41b13f39dda75f68"
+  url "https://github.com/bugsnag/bugsnag-dsym-upload/archive/refs/tags/v2.2.0.tar.gz"
+  sha256 "5f2a9170cbd82720e4cb91bda74bed8665f0cdae98c6f4290846bd5d89e04e3d"
   license "MIT"
   head "https://github.com/bugsnag/bugsnag-dsym-upload"
   bottle :unneeded


### PR DESCRIPTION
## Goal

Following https://github.com/bugsnag/bugsnag-dsym-upload/releases/tag/v2.2.0, update the Homebrew tap to point to this new release.