### PR TITLE
update formula to point to bugsnag-dsym-upload v2.2.1

### DIFF
--- a/Formula/bugsnag-dsym-upload.rb
+++ b/Formula/bugsnag-dsym-upload.rb
@@ -5,7 +5,6 @@ class BugsnagDsymUpload < Formula
   sha256 "bf6517b0d437adc167bc42b97376b46f41f7773ac0faaa9ed8697ce0082a5277"
   license "MIT"
   head "https://github.com/bugsnag/bugsnag-dsym-upload"
-  bottle :unneeded
 
   def install
     system "make", "BINDIR=#{bin}", "MANDIR=#{man}", "install"

--- a/Formula/bugsnag-dsym-upload.rb
+++ b/Formula/bugsnag-dsym-upload.rb
@@ -1,8 +1,8 @@
 class BugsnagDsymUpload < Formula
   desc "Commands for uploading files to Bugsnag via the upload APIs"
   homepage "https://docs.bugsnag.com/api/dsym-upload"
-  url "https://github.com/bugsnag/bugsnag-dsym-upload/archive/refs/tags/v2.2.0.tar.gz"
-  sha256 "5f2a9170cbd82720e4cb91bda74bed8665f0cdae98c6f4290846bd5d89e04e3d"
+  url "https://github.com/bugsnag/bugsnag-dsym-upload/archive/refs/tags/v2.2.1.tar.gz"
+  sha256 "bf6517b0d437adc167bc42b97376b46f41f7773ac0faaa9ed8697ce0082a5277"
   license "MIT"
   head "https://github.com/bugsnag/bugsnag-dsym-upload"
   bottle :unneeded


### PR DESCRIPTION
## Goal

Following https://github.com/bugsnag/bugsnag-dsym-upload/releases/tag/v2.2.1, update the Homebrew tap to point to this new release.

SHA confirmation
```
> $ brew create https://github.com/bugsnag/bugsnag-dsym-upload/archive/refs/tags/v2.2.1.tar.gz                                                                                       ⬡ 14.15.4 [±master ✓]
==> Downloading https://github.com/bugsnag/bugsnag-dsym-upload/archive/refs/tags/v2.2.1.tar.gz
==> Downloading from https://codeload.github.com/bugsnag/bugsnag-dsym-upload/tar.gz/refs/tags/v2.2.1
      # -=#=- #     #                                                         
For your reference, the checksum is:
  sha256 "bf6517b0d437adc167bc42b97376b46f41f7773ac0faaa9ed8697ce0082a5277"
```

Additionally remove `bottle :unneeded`. This is now deprecated and has no replacement. As this formula isn't in `homebrew-core` anyway, it's not required.