### PR TITLE
Bumpsnag action updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,9 @@ jobs:
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
           restore-keys: ${{ runner.os }}-rubygems-
 
+      # Not used during this workflow - can cause issues with Homebrews linting and style checks
+      - run: rm Gemfile
+
       - name: Install Homebrew Bundler RubyGems
         if: steps.cache.outputs.cache-hit != 'true'
         run: brew install-bundler-gems
@@ -29,8 +32,6 @@ jobs:
       - run: brew test-bot --only-cleanup-before
 
       - run: brew test-bot --only-setup
-        env:
-          HOMEBREW_NO_BUNDLE: 1
 
       - run: brew test-bot --only-tap-syntax
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,8 @@ jobs:
       - run: brew test-bot --only-cleanup-before
 
       - run: brew test-bot --only-setup
+        env:
+          HOMEBREW_NO_BUNDLE: 1
 
       - run: brew test-bot --only-tap-syntax
 

--- a/.github/workflows/update-cli.yml
+++ b/.github/workflows/update-cli.yml
@@ -19,11 +19,8 @@ jobs:
       BUNDLE_GITHUB__COM: ${{ secrets.BUNDLE_ACCESS_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-
       - name: Check out code
         uses: actions/checkout@v4
-        with:
-          ref: next
 
       - name: Configure Git
         run: |
@@ -45,8 +42,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install -y ruby jq gh
-          gem install bundler
           bundle install
 
       - name: Remove leading 'v'

--- a/.github/workflows/update-cli.yml
+++ b/.github/workflows/update-cli.yml
@@ -22,6 +22,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
+      - name: Get current branch
+        id: current-branch
+        run: echo "branch=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
       - name: Configure Git
         run: |
           git config --global user.name "Bumpsnag Bot"
@@ -47,7 +51,7 @@ jobs:
       - name: Remove leading 'v'
         shell: bash
         run: |
-          echo "CLI_VERSION=${RAW_VERSION#v}" >> $GITHUB_ENV
+          echo "CLI_VERSION=${RAW_VERSION#v}" >> "$GITHUB_ENV"
 
       - name: Update Homebrew formula with new version and SHA256 checksums
         shell: bash
@@ -87,13 +91,13 @@ jobs:
 
       - name: Create bump commit
         run: |
-          bundle exec bumpsnag commit-update $TARGET_REPO $RAW_VERSION
+          bundle exec bumpsnag commit-update "$TARGET_REPO" "$RAW_VERSION"
 
       - name: Create pull request
         if: ${{ steps.current-branch.outputs.branch != 'master'}}
         run: >
           gh pr create -B master
-          -H bumpsnag-$TARGET_REPO-$RAW_VERSION
+          -H bumpsnag-"$TARGET_REPO"-"$RAW_VERSION"
           --title "Update $TARGET_REPO to version $RAW_VERSION"
           --body 'Created by bumpsnag'
           --reviewer joshedney

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.1.0] - 2025-10-08
+
+### Added
+
+- Add `bugsnag-cli` to the available formulae in the Bugsnag Homebrew Tap [#11](https://github.com/bugsnag/homebrew-tap/pull/11)

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+# Only install bumpsnag if we're using Github actions
+unless ENV['GITHUB_ACTIONS'].nil?
+  gem 'bumpsnag', git: 'https://github.com/bugsnag/platforms-bumpsnag', branch: 'main'
+end


### PR DESCRIPTION
## Goal

Add the `bumpsnag` gem 

## Testing

Formatting tests pass locally - Will investigate CI failures separately from this ticket

```
==> Using Homebrew/brew 4.6.17-67-g00001bedf8 (Merge pull request #20908 from Homebrew/fix-doctor-missing-deps-warning)
==> Using Homebrew/homebrew-core 6416403e930 (Merge pull request #250343 from Homebrew/bump-readsb-3.16.5)

==> Running TapSyntax#run!
==> brew typecheck homebrew/core
==> brew style homebrew/core
==> brew readall --aliases --os=all --arch=all homebrew/core
==> brew audit --except=installed --tap=homebrew/core
All steps passed!
```

Tested by triggering the action manually
https://github.com/bugsnag/homebrew-tap/pull/13